### PR TITLE
Adding a mechanism to disable an origin

### DIFF
--- a/smart-contracts/test/RelayPool/claim.hardhat.ts
+++ b/smart-contracts/test/RelayPool/claim.hardhat.ts
@@ -52,6 +52,7 @@ describe('RelayBridge: claim', () => {
       maxDebt: ethers.parseEther('10'),
       proxyBridge: await oPStackNativeBridgeProxy.getAddress(),
       bridgeFee: 10,
+      curator: userAddress,
     })
 
     // deploy the pool using ignition

--- a/smart-contracts/test/RelayPool/fees.hardhat.ts
+++ b/smart-contracts/test/RelayPool/fees.hardhat.ts
@@ -51,6 +51,7 @@ describe('Fees', () => {
             maxDebt: ethers.parseEther('10'),
             proxyBridge: oPStackNativeBridgeProxy,
             bridgeFee: 5, // (0.05%)
+            curator: userAddress,
           },
         ],
         thirdPartyPool: await thirdPartyPool.getAddress(),
@@ -72,7 +73,7 @@ describe('Fees', () => {
     const recipientAddress = ethers.Wallet.createRandom().address
 
     const amount = ethers.parseUnits('1')
-    const [, , , bridgeFee] = await relayPool.authorizedOrigins(
+    const [, , , , bridgeFee] = await relayPool.authorizedOrigins(
       10,
       relayBridgeOptimism
     )

--- a/smart-contracts/test/RelayPool/hyperlane.hardhat.ts
+++ b/smart-contracts/test/RelayPool/hyperlane.hardhat.ts
@@ -52,6 +52,7 @@ describe('ERC20 RelayBridge: when receiving a message from the Hyperlane Mailbox
             maxDebt: ethers.parseEther('10'),
             proxyBridge: oPStackNativeBridgeProxy,
             bridgeFee: 0,
+            curator: userAddress,
           },
         ],
         thirdPartyPool: await thirdPartyPool.getAddress(),
@@ -188,7 +189,7 @@ describe('ERC20 RelayBridge: when receiving a message from the Hyperlane Mailbox
       originChainId,
       originBridge
     )
-    expect(originSettingsAfter[1]).to.equal(originSettingsBefore[1] + amount)
+    expect(originSettingsAfter[2]).to.equal(originSettingsBefore[2] + amount)
   })
 
   it('should transfer the assets from the pool to the recipient', async () => {
@@ -326,6 +327,7 @@ describe('WETH RelayBridge: when receiving a message from the Hyperlane Mailbox'
             maxDebt: ethers.parseEther('10'),
             proxyBridge: oPStackNativeBridgeProxy,
             bridgeFee: 0,
+            curator: userAddress,
           },
         ],
         thirdPartyPool: await thirdPartyPool.getAddress(),


### PR DESCRIPTION
For this, we cannot use the pool's curator because this may need to be very fast and the curator should be a timelock.

https://github.com/unlock-protocol/relay-protocol/issues/96